### PR TITLE
Fixed nullability of returnAb

### DIFF
--- a/flipper/src/main/kotlin/com/redmadrobot/flipper/FlipperExt.kt
+++ b/flipper/src/main/kotlin/com/redmadrobot/flipper/FlipperExt.kt
@@ -2,8 +2,6 @@ package com.redmadrobot.flipper
 
 import android.view.MenuItem
 import android.view.View
-import org.jetbrains.annotations.NotNull
-import org.jetbrains.annotations.Nullable
 
 fun flipperPoint(feature: Feature, action: () -> Unit) {
     ToggleRouter.flip(feature, action)
@@ -13,8 +11,7 @@ fun flipperPointAb(feature: Feature, actionA: () -> Unit, actionB: () -> Unit) {
     ToggleRouter.flipAb(feature, actionA, actionB)
 }
 
-@Nullable
-fun <T> flipperPointAb(feature: Feature, valueA: T?, valueB: T?): T? {
+fun <T> flipperPointAb(feature: Feature, valueA: T, valueB: T): T {
     return ToggleRouter.returnAb(feature, valueA, valueB)
 }
 
@@ -34,5 +31,4 @@ fun MenuItem.flipperPointAb(feature: Feature, alternativeMenuItem: MenuItem) {
     ToggleRouter.flipAb(feature, this, alternativeMenuItem)
 }
 
-@NotNull
-fun flipperPointIsEnabled(feature: Feature) = ToggleRouter.featureIsEnabled(feature)
+fun flipperPointIsEnabled(feature: Feature): Boolean = ToggleRouter.featureIsEnabled(feature)

--- a/flipper/src/main/kotlin/com/redmadrobot/flipper/ToggleRouter.kt
+++ b/flipper/src/main/kotlin/com/redmadrobot/flipper/ToggleRouter.kt
@@ -3,8 +3,6 @@ package com.redmadrobot.flipper
 import android.view.MenuItem
 import android.view.View
 import com.redmadrobot.flipper.config.FlipperConfig
-import org.jetbrains.annotations.NotNull
-import org.jetbrains.annotations.Nullable
 
 
 object ToggleRouter {
@@ -34,13 +32,11 @@ object ToggleRouter {
         }
     }
 
-    @Nullable
-    internal fun <T>  returnAb(feature: Feature, valueA: T?, valueB: T?): T? {
+    internal fun <T> returnAb(feature: Feature, valueA: T, valueB: T): T {
         return if (configuration.featureIsEnabled(feature)) valueA else valueB
     }
 
-    @NotNull
-    internal fun featureIsEnabled(feature: Feature) = configuration.featureIsEnabled(feature)
+    internal fun featureIsEnabled(feature: Feature): Boolean = configuration.featureIsEnabled(feature)
 
     private fun flipView(feature: Feature, view: View) {
         view.visibility = if (configuration.featureIsEnabled(feature)) View.VISIBLE else View.GONE

--- a/flipper/src/test/java/com/redmadrobot/flipper/ToggleRouterTest.kt
+++ b/flipper/src/test/java/com/redmadrobot/flipper/ToggleRouterTest.kt
@@ -8,6 +8,7 @@ import com.redmadrobot.flipper.support.TestConfig
 import com.redmadrobot.flipper.support.TestFeature
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -211,7 +212,7 @@ class ToggleRouterTest {
     }
 
     @Test
-    fun `when feature is enabled - then return B-value`() {
+    fun `when feature is disabled - then return B-value`() {
         // Given
         val precalculatedValueA = "valueA"
         val precalculatedValueB = "valueB"
@@ -239,5 +240,39 @@ class ToggleRouterTest {
         val result = ToggleRouter.featureIsEnabled(TestFeature)
 
         assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `when use returnAb - and one of values is nullable - should return nullable result`() {
+        // Given
+        val precalculatedValueA = "valueA"
+        val precalculatedValueB = null
+
+        // When
+        val result = ToggleRouter.returnAb(TestFeature, precalculatedValueA, precalculatedValueB)
+
+        assertNullable(result)
+    }
+
+    @Test
+    fun `when use returnAb - and both values are non-nullable - should return non-nullable result`() {
+        // Given
+        val precalculatedValueA = "valueA"
+        val precalculatedValueB = "valueB"
+
+        // When
+        val result = ToggleRouter.returnAb(TestFeature, precalculatedValueA, precalculatedValueB)
+
+        assertNotNullable(result)
+    }
+
+    @Suppress("UNUSED_PARAMETER") // Parameter needed for type inference
+    private inline fun <reified T> assertNullable(t: T) {
+        assertTrue(null is T)
+    }
+
+    @Suppress("UNUSED_PARAMETER") // Parameter needed for type inference
+    private inline fun <reified T> assertNotNullable(t: T) {
+        assertTrue(null !is T)
     }
 }


### PR DESCRIPTION
It was impossible to get a non-nullable value from `returnAb` function. I've fixed it and added tests for this case.