### PR TITLE
Remove tests running from script because it included to build task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ android:
     - android-sdk-license-.+
 
 script:
-  - ./gradlew :flipper:test
   - ./gradlew :flipper:build
 
 before_install:


### PR DESCRIPTION
Build task runs both `check` (that runs `test`) and `assemble`